### PR TITLE
Refactor tag handling and improve custom tag support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+.history

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## Refactor tag handlers to use function maps
+
+Refactored the interpreter to use a map of tag handlers instead of a large switch statement. This makes the code more maintainable and easier to extend with new tags.
+
+- Moved all tag handlers to a defaultHandlers map
+- Updated TagFunc signature to include interpreter instance
+- Modified Process method to use the handlers map
+- Updated RegisterTag to wrap old-style functions to match new signature 
+
+## Comprehensive Documentation Update
+
+Added comprehensive documentation for Emrichen in the topics section, providing a complete overview of the templating engine's capabilities and best practices.
+
+- Added detailed explanation of core features and functionality
+- Included practical examples for common use cases
+- Added best practices and performance considerations
+- Documented advanced topics and template composition strategies
+- Added detailed explanations for each major feature
+- Added information about built-in help commands
+- Expanded examples with detailed explanations 

--- a/pkg/doc/topics/01-emrichen.md
+++ b/pkg/doc/topics/01-emrichen.md
@@ -11,5 +11,182 @@ ShowPerDefault: true
 SectionType: GeneralTopic
 ---
 
-## Overview
+# Emrichen: A YAML Templating Engine
+
+Emrichen is a powerful templating engine specifically designed for generating and manipulating YAML configurations. Unlike traditional text-based templating systems, Emrichen understands YAML's structure, enabling robust and type-safe template processing while avoiding common pitfalls like indentation errors and type mismatches.
+
+## Getting Help
+
+Emrichen provides comprehensive built-in help features that you can access through the command line:
+
+- `emrichen help --all`: Display all available documentation topics
+- `emrichen help --examples`: Show practical examples for common use cases
+- `emrichen help tag-<name>`: Get detailed information about a specific tag (e.g., `emrichen help tag-op`)
+
+## Core Features
+
+### Variable Management
+- **Variable Definition**: Use `!Defaults` to define default values
+- **Variable Substitution**: Access variables using `!Var`
+- **Scoped Variables**: Create local variable scopes with `!With`
+
+Variables in Emrichen serve as the foundation for template reusability and configuration. The `!Defaults` tag allows you to define a set of default values at the beginning of your template, which can be overridden when needed. These variables can be simple scalar values, lists, or complex nested structures.
+
+The `!With` tag creates a new scope for variables, allowing you to work with temporary values without affecting the global scope. This is particularly useful when working with loops or when you need to transform data temporarily.
+
+### Control Flow
+- **Conditional Logic**: Use `!If` for conditional processing
+- **Loops**: Iterate over collections with `!Loop`
+- **Error Handling**: Control error behavior with `!Error` and debug with `!Debug`
+
+Control flow in Emrichen is designed to be both powerful and intuitive. The `!If` tag supports complex conditions through the `!Op` tag, allowing you to create sophisticated conditional logic. For example, you can combine multiple conditions using logical operators or perform numerical comparisons.
+
+The `!Loop` tag is a versatile tool for iterating over collections. It provides features like index tracking, access to the previous item, and the ability to filter items during iteration. This makes it ideal for generating repetitive configurations while maintaining flexibility.
+
+### Data Manipulation
+- **List Operations**: Concatenate lists with `!Concat`, join elements with `!Join`
+- **Dictionary Operations**: Merge dictionaries with `!Merge`
+- **Filtering**: Filter collections using `!Filter`
+- **Grouping**: Group data with `!Group` and `!Index`
+- **String Formatting**: Format strings using `!Format` with Go template syntax
+
+Data manipulation in Emrichen goes beyond simple variable substitution. The `!Merge` tag allows you to combine multiple dictionaries, with later values taking precedence. This is particularly useful when working with configuration overlays or environment-specific settings.
+
+The `!Format` tag supports Go's powerful template syntax, enabling complex string formatting operations. You can access nested data structures, apply formatting functions, and even use conditional logic within your format strings.
+
+### Advanced Features
+- **File Inclusion**: Include other YAML files with `!Include`
+- **URL Handling**: Encode URLs and query parameters with `!URLEncode`
+- **Type Checking**: Validate types with `!IsString`, `!IsNumber`, etc.
+- **Lookup Operations**: Access nested data using `!Lookup`
+
+File inclusion through the `!Include` tag enables modular template design. You can break down complex configurations into smaller, reusable components and include them as needed. This supports both YAML and binary files, with options for base64 encoding when required.
+
+The lookup system, implemented through the `!Lookup` tag, provides a powerful way to access nested data structures using JSONPath-like syntax. This makes it easy to work with complex data structures while maintaining readable templates.
+
+## Basic Usage Examples
+
+### Variable Substitution
+```yaml
+!Defaults
+name: John
+greeting: Hello
+---
+message: !Format "{{.greeting}}, {{.name}}!"
+```
+
+In this example, we define two variables and use them in a format string. The `!Format` tag uses Go's template syntax, allowing for more complex formatting operations when needed.
+
+### Conditional Processing
+```yaml
+!Defaults
+is_production: true
+---
+environment: !If
+  test: !Var is_production
+  then: production
+  else: development
+```
+
+The `!If` tag demonstrates Emrichen's conditional processing capabilities. You can use complex conditions by combining the `!Op` tag with various operators.
+
+### Looping and Data Transformation
+```yaml
+!Defaults
+ports: [80, 443, 8080]
+---
+container_ports: !Loop
+  over: !Var ports
+  template:
+    port: !Var item
+    protocol: TCP
+```
+
+This example shows how to transform a simple list into a more complex structure using the `!Loop` tag. The `item` variable automatically contains the current item being processed.
+
+### Working with Complex Data
+```yaml
+!Defaults
+services:
+  - name: web
+    port: 80
+  - name: api
+    port: 8080
+---
+deployments: !Loop
+  over: !Var services
+  template:
+    name: !Format "{{.item.name}}-service"
+    port: !Var item.port
+```
+
+Here we demonstrate working with structured data, showing how to access nested properties and transform them into a new format.
+
+## Best Practices
+
+1. **Variable Organization**
+   - Keep default values organized in a single `!Defaults` section
+   - Use meaningful variable names
+   - Consider using `!With` for local variable scoping
+
+Organizing variables effectively is crucial for maintaining readable and maintainable templates. The `!Defaults` section should be placed at the beginning of your template, clearly documenting all available configuration options.
+
+2. **Error Handling**
+   - Use `!Debug` for troubleshooting
+   - Implement proper error handling with `!Error`
+   - Validate data types when necessary
+
+Error handling in Emrichen is proactive. The `!Debug` tag helps you inspect variables during template processing, while `!Error` allows you to fail fast when invalid conditions are detected. Type validation tags help ensure data consistency.
+
+3. **Code Structure**
+   - Break down complex templates into smaller, reusable components
+   - Use `!Include` to maintain modular templates
+   - Comment your YAML files for clarity
+
+Modular template design is essential for managing complex configurations. Use the `!Include` tag to split your templates into logical components, and maintain a clear directory structure for included files.
+
+4. **Performance Considerations**
+   - Use `!Filter` before `!Loop` to reduce iterations
+   - Avoid deeply nested template structures
+   - Consider caching frequently used values in variables
+
+Performance optimization in Emrichen often involves reducing the number of operations performed. The `!Filter` tag can significantly improve performance by reducing the dataset before processing.
+
+## Common Use Cases
+
+1. **Kubernetes Configurations**
+   - Generate deployment manifests
+   - Manage service configurations
+   - Handle environment-specific settings
+
+Kubernetes configurations benefit greatly from Emrichen's templating capabilities. You can maintain a single template that adapts to different environments while ensuring consistency across your infrastructure.
+
+2. **Application Configuration**
+   - Generate config files for different environments
+   - Manage feature flags
+   - Handle service dependencies
+
+Application configuration management becomes more manageable with Emrichen's variable system and conditional processing. You can maintain different configurations for development, staging, and production environments while sharing common settings.
+
+3. **Infrastructure as Code**
+   - Template cloud resource definitions
+   - Manage infrastructure configurations
+   - Generate deployment scripts
+
+Infrastructure as Code benefits from Emrichen's ability to handle complex data structures and its support for modular templates. You can maintain reusable infrastructure components while allowing for customization.
+
+## Advanced Topics
+
+### Custom Tags
+Emrichen supports extending its functionality through custom tags, allowing you to add domain-specific templating capabilities. Custom tags can be implemented to handle specific use cases or to integrate with external systems.
+
+### Template Composition
+Complex templates can be broken down into smaller, reusable components using `!Include` and `!With` tags for better maintainability. This modular approach allows you to build a library of reusable template components.
+
+### Error Handling and Debugging
+The `!Debug` and `!Error` tags provide powerful tools for troubleshooting and handling edge cases in your templates. Combined with type validation tags, they help ensure your templates remain robust and maintainable.
+
+## Conclusion
+
+Emrichen provides a robust and flexible solution for YAML templating needs. Its understanding of YAML structure, combined with powerful features like variable management, control flow, and data manipulation, makes it an excellent choice for managing complex configurations in modern software development workflows. The comprehensive help system and extensive documentation make it easy to learn and master Emrichen's capabilities.
 

--- a/pkg/doc/topics/02-adding-custom-tags.md
+++ b/pkg/doc/topics/02-adding-custom-tags.md
@@ -1,0 +1,624 @@
+---
+Title: Adding Custom Tags
+Slug: adding-custom-tags
+Topics:
+  - development
+  - customization
+Commands:
+  - help
+IsTemplate: false
+IsTopLevel: true
+ShowPerDefault: true
+SectionType: DevelopmentTopic
+---
+
+# Adding Custom Tags to Go-Emrichen
+
+Go-Emrichen's functionality can be extended through custom tags, allowing you to add domain-specific templating capabilities. This guide explains how to implement custom tags and integrate them with the Go-Emrichen interpreter.
+
+## Understanding Tag Processing
+
+At its core, Go-Emrichen treats YAML as a tree of nodes that can be transformed through tag handlers. Each tag represents a specific transformation operation on these nodes. When the interpreter encounters a tag, it delegates the processing to the corresponding handler function, which can:
+
+- Transform the node's value
+- Create new nodes
+- Access and modify variables in the environment
+- Process child nodes recursively
+
+This node-based approach provides several advantages:
+- Type safety through YAML's typing system
+- Preservation of YAML structure during transformations
+- Clear separation between parsing and processing
+- Ability to handle complex nested structures
+
+## Basic Tag Implementation
+
+Custom tags in Go-Emrichen are implemented as functions that process YAML nodes. The basic signature for a tag handler is:
+
+```go
+import (
+    "github.com/go-go-golems/go-emrichen/pkg/emrichen"
+    "gopkg.in/yaml.v3"
+)
+
+type TagFunc func(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error)
+```
+
+This signature provides access to both:
+- The interpreter instance (`ei`) for environment access and node processing
+- The YAML node to be processed (`node`)
+
+Here's a simple example of a custom tag that converts text to uppercase:
+
+```go
+import (
+    "strings"
+    "github.com/go-go-golems/go-emrichen/pkg/emrichen"
+    "github.com/pkg/errors"
+    "gopkg.in/yaml.v3"
+)
+
+func handleUppercase(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    if node.Kind != yaml.ScalarNode {
+        return nil, errors.New("!Uppercase requires a scalar node")
+    }
+    return &yaml.Node{
+        Kind:  yaml.ScalarNode,
+        Value: strings.ToUpper(node.Value),
+    }, nil
+}
+```
+
+### Registering Custom Tags
+
+Custom tags are registered when creating a new interpreter. The registration process maps tag names to their handler functions, allowing the interpreter to look up the appropriate handler when processing YAML:
+
+```go
+customTags := map[string]emrichen.TagFunc{
+    "!Uppercase": handleUppercase,
+}
+
+interpreter, err := emrichen.NewInterpreter(
+    emrichen.WithAdditionalTags(customTags),
+)
+```
+
+Note that tag handlers are pure functions - they don't modify the interpreter state directly. Instead, they receive the interpreter instance as an argument, which provides access to the environment and utility functions.
+
+## Working with Arguments
+
+Many tags need to handle complex arguments. Go-Emrichen provides a structured approach to argument handling that ensures:
+- Clear validation of required arguments
+- Type safety for argument values
+- Support for optional arguments with defaults
+- Variable expansion when needed
+- Consistent error handling
+- Recursive processing of nested structures
+
+This structured approach helps prevent runtime errors and provides clear error messages when arguments are missing or invalid.
+
+### Core Principles
+
+When implementing tag handlers, follow these core principles:
+1. **Always Use ParseArgs**: Use the `ParseArgs` method to handle arguments instead of processing them manually. This ensures consistent behavior and proper error handling.
+2. **Process Recursively**: All sub-fields should be processed recursively using the interpreter's `Process` method to ensure proper handling of nested tags and variables.
+3. **Handle Expansion**: Use the `Expand` flag in `ParsedVariable` to control when variable substitution occurs.
+
+### Argument Definition
+
+Arguments are defined using the `ParsedVariable` struct, which encapsulates the validation rules for each argument:
+
+```go
+type ParsedVariable struct {
+    Name     string  // The argument name in the YAML
+    Required bool    // Whether the argument must be provided
+    Expand   bool    // Whether to process variables in the argument value
+}
+```
+
+The `Expand` field is particularly important as it determines whether the argument value should be processed for variable substitution before being used. This allows for dynamic argument values while maintaining control over when expansion occurs.
+
+### Using ParseArgs
+
+The `ParseArgs` method is a core utility function that processes YAML mapping nodes according to a list of variable specifications. It provides:
+
+1. **Consistent Argument Handling**:
+   - Validates the input node is a mapping node
+   - Checks for unknown argument keys
+   - Ensures required arguments are present
+   - Verifies keys are scalar values
+
+2. **Variable Expansion Control**:
+   - Processes values through the interpreter when `Expand` is true
+   - Preserves raw values when `Expand` is false
+   - Handles nested structures properly
+
+3. **Type Safety**:
+   - Maintains YAML node types
+   - Provides clear error messages for type mismatches
+   - Preserves node metadata
+
+Here's a complete example of proper argument handling:
+
+```go
+func handleCustomTag(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    args, err := ei.ParseArgs(node, []emrichen.ParsedVariable{
+        {Name: "input", Required: true, Expand: true},    // Will be processed for variables
+        {Name: "format", Required: false},                // Optional, no expansion
+        {Name: "options", Expand: true},                  // Optional with expansion
+    })
+    if err != nil {
+        return nil, err
+    }
+    
+    // Access and validate arguments
+    inputNode := args["input"]
+    if inputNode.Kind != yaml.ScalarNode {
+        return nil, errors.New("input must be a scalar value")
+    }
+
+    // Optional argument handling
+    var format string
+    if formatNode, ok := args["format"]; ok {
+        formatStr, ok := emrichen.NodeToString(formatNode)
+        if !ok {
+            return nil, errors.New("format must be a string")
+        }
+        format = formatStr
+    }
+
+    // Process nested structures
+    if optionsNode, ok := args["options"]; ok {
+        // Options were already expanded by ParseArgs if found
+        // Process them according to your tag's logic
+        result, err := processOptions(ei, optionsNode)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to process options")
+        }
+        // Use the processed result
+    }
+
+    // Return processed result
+    return processedNode, nil
+}
+```
+
+### Recursive Processing
+
+When working with nested structures, always ensure proper recursive processing:
+
+```go
+func handleNestedStructure(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    args, err := ei.ParseArgs(node, []emrichen.ParsedVariable{
+        {Name: "data", Required: true, Expand: true},
+        {Name: "template", Required: true},  // Not expanded initially
+    })
+    if err != nil {
+        return nil, err
+    }
+
+    // Process the template with the expanded data
+    dataNode := args["data"]
+    templateNode := args["template"]
+
+    // Create a new scope with the processed data
+    result := &yaml.Node{}
+    err = ei.env.With(map[string]interface{}{
+        "data": emrichen.NodeToInterface(dataNode),
+    }, func() error {
+        // Now process the template in the new scope
+        processed, err := ei.Process(templateNode)
+        if err != nil {
+            return err
+        }
+        *result = *processed
+        return nil
+    })
+    
+    return result, err
+}
+```
+
+### Error Handling in Argument Processing
+
+When using ParseArgs, handle errors appropriately:
+
+```go
+func handleWithErrorChecking(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    args, err := ei.ParseArgs(node, []emrichen.ParsedVariable{
+        {Name: "source", Required: true, Expand: true},
+    })
+    if err != nil {
+        // ParseArgs already provides detailed error messages
+        return nil, errors.Wrap(err, "invalid arguments")
+    }
+
+    // Additional type-specific validation
+    sourceNode := args["source"]
+    switch sourceNode.Kind {
+    case yaml.ScalarNode:
+        // Handle scalar case
+    case yaml.SequenceNode:
+        // Handle sequence case
+    case yaml.MappingNode:
+        // Handle mapping case
+    default:
+        return nil, errors.Errorf("unexpected node kind for source: %v", sourceNode.Kind)
+    }
+
+    // Process the node
+    return processedNode, nil
+}
+```
+
+## Environment Interaction
+
+The environment in Go-Emrichen serves as a shared context for variable storage and retrieval. It's designed to support:
+- Hierarchical scoping of variables
+- Safe concurrent access
+- Temporary variable overrides
+- Clean variable cleanup
+
+Understanding how to interact with the environment is crucial for creating tags that work well with variables and maintain proper scoping.
+
+### Accessing Variables
+
+Variable access is mediated through the environment to ensure consistency and proper scoping:
+
+```go
+func handleVarAccess(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    varName := node.Value
+    varValue, exists := ei.env.GetVar(varName)
+    if !exists {
+        return nil, errors.Errorf("variable %s not found", varName)
+    }
+    return emrichen.ValueToNode(varValue)
+}
+```
+
+### Scoped Variables
+
+The `With` method provides a powerful way to create temporary variable scopes. This is essential for:
+- Isolating variable changes
+- Preventing variable leakage
+- Managing cleanup automatically
+- Supporting nested scopes
+
+```go
+func handleScopedOperation(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    tempVars := map[string]interface{}{
+        "tempVar": "value",
+    }
+    
+    var result *yaml.Node
+    err := ei.env.With(tempVars, func() error {
+        var err error
+        result, err = ei.Process(node)
+        return err
+    })
+    return result, err
+}
+```
+
+## Node Processing
+
+YAML nodes are the fundamental data structure in Go-Emrichen. Understanding how to work with them effectively is crucial for creating robust tags. The node processing utilities provide:
+- Type-safe conversions
+- Structured node creation
+- Error handling
+- Performance optimization
+
+### Converting Values
+
+Value conversion is a common operation that needs to be handled carefully to maintain type safety and provide clear error messages:
+
+```go
+// Go value to YAML node
+value := "example"
+node, err := emrichen.ValueToNode(value)
+
+// YAML node to interface{}
+if val, ok := emrichen.NodeToInterface(node); ok {
+    // Use val
+}
+
+// Type-specific conversions
+if intVal, ok := emrichen.NodeToInt(node); ok {
+    // Use intVal
+}
+```
+
+### Creating Nodes
+
+Node creation follows specific patterns to ensure consistency and proper YAML structure:
+
+```go
+// Scalar node
+scalarNode := &yaml.Node{
+    Kind:  yaml.ScalarNode,
+    Value: "value",
+    Tag:   "!!str",
+}
+
+// Sequence node
+seqNode := &yaml.Node{
+    Kind:    yaml.SequenceNode,
+    Tag:     "!!seq",
+    Content: []*yaml.Node{...},
+}
+
+// Mapping node
+mapNode := &yaml.Node{
+    Kind:    yaml.MappingNode,
+    Tag:     "!!map",
+    Content: []*yaml.Node{...},
+}
+```
+
+## Advanced Features
+
+Advanced features in Go-Emrichen build upon the basic concepts to provide powerful functionality. Understanding these features helps create more sophisticated tags.
+
+### Template Processing
+
+Template processing is a recursive operation that allows tags to work with complex nested structures:
+
+```go
+func handleTemplate(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    // Process template with current environment
+    result, err := ei.Process(templateNode)
+    if err != nil {
+        return nil, err
+    }
+    return result, nil
+}
+```
+
+### Conditional Evaluation
+
+Conditional logic in tags should be implemented carefully to ensure proper evaluation of conditions and handling of both branches:
+
+```go
+func handleCondition(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    if isTruthy(conditionNode) {
+        return ei.Process(thenNode)
+    }
+    return ei.Process(elseNode)
+}
+```
+
+### Error Handling
+
+Proper error handling is crucial for debugging and maintaining templates. Errors should be:
+- Descriptive and actionable
+- Properly wrapped for context
+- Handled at appropriate levels
+- Clear about what went wrong
+
+```go
+func handleComplexOperation(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    // Validate input
+    if node.Kind != yaml.MappingNode {
+        return nil, errors.New("expected mapping node")
+    }
+    
+    // Handle nested errors
+    result, err := someOperation()
+    if err != nil {
+        return nil, errors.Wrap(err, "operation failed")
+    }
+    
+    // Return processed result
+    return emrichen.ValueToNode(result)
+}
+```
+
+## Complete Example
+
+The following example demonstrates how these concepts come together in a practical tag implementation. It shows:
+- Proper argument handling
+- Clear error messages
+- Type safety
+- Clean code structure
+
+```go
+func handlePrefix(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    args, err := ei.ParseArgs(node, []emrichen.ParsedVariable{
+        {Name: "text", Required: true},
+        {Name: "prefix", Required: true},
+    })
+    if err != nil {
+        return nil, err
+    }
+    
+    // Get text value
+    text, ok := emrichen.NodeToString(args["text"])
+    if !ok {
+        return nil, errors.New("text must be a string")
+    }
+    
+    // Get prefix value
+    prefix, ok := emrichen.NodeToString(args["prefix"])
+    if !ok {
+        return nil, errors.New("prefix must be a string")
+    }
+    
+    // Create result node
+    return &yaml.Node{
+        Kind:  yaml.ScalarNode,
+        Tag:   "!!str",
+        Value: prefix + text,
+    }, nil
+}
+```
+
+Usage in YAML:
+
+```yaml
+formatted: !Prefix
+  text: Hello World
+  prefix: ">> "
+```
+
+## Best Practices
+
+These best practices are derived from real-world experience with template processing and aim to create robust, maintainable tags:
+
+1. **Input Validation**: Always validate input node types and arguments before processing.
+2. **Error Messages**: Provide clear error messages that help users understand what went wrong.
+3. **Documentation**: Document your custom tags with examples and parameter descriptions.
+4. **Type Safety**: Use type conversion utilities to safely handle different value types.
+5. **Scoped Changes**: Use `With` for temporary environment modifications.
+6. **Testing**: Write comprehensive tests for your custom tags.
+
+## Testing Custom Tags
+
+Testing is crucial for ensuring tag reliability. A good test suite should cover:
+- Basic functionality
+- Edge cases
+- Error conditions
+- Complex inputs
+- Performance characteristics
+
+```go
+func TestCustomTag(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    string
+        expected string
+        wantErr  bool
+    }{
+        {
+            name:     "basic usage",
+            input:    "!CustomTag value",
+            expected: "processed value",
+            wantErr:  false,
+        },
+        {
+            name:     "invalid input",
+            input:    "!CustomTag {invalid: input}",
+            wantErr:  true,
+        },
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // Parse input YAML
+            var node yaml.Node
+            err := yaml.Unmarshal([]byte(tt.input), &node)
+            require.NoError(t, err)
+            
+            // Create interpreter with custom tag
+            interpreter, err := emrichen.NewInterpreter(
+                emrichen.WithAdditionalTags(map[string]emrichen.TagFunc{
+                    "!CustomTag": handleCustomTag,
+                }),
+            )
+            require.NoError(t, err)
+            
+            // Process node
+            result, err := interpreter.Process(&node)
+            
+            if tt.wantErr {
+                assert.Error(t, err)
+                return
+            }
+            
+            assert.NoError(t, err)
+            assert.Equal(t, tt.expected, result.Value)
+        })
+    }
+}
+```
+
+## Common Patterns
+
+These patterns emerge from common use cases and provide tested solutions to recurring problems.
+
+### Handling Collections
+
+Collection handling requires careful attention to:
+- Maintaining order
+- Proper error propagation
+- Memory efficiency
+- Type consistency
+
+```go
+func handleCollection(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    switch node.Kind {
+    case yaml.SequenceNode:
+        // Process sequence items
+        var results []*yaml.Node
+        for _, item := range node.Content {
+            result, err := processItem(ei, item)
+            if err != nil {
+                return nil, err
+            }
+            results = append(results, result)
+        }
+        return &yaml.Node{
+            Kind:    yaml.SequenceNode,
+            Tag:     "!!seq",
+            Content: results,
+        }, nil
+        
+    case yaml.MappingNode:
+        // Process key-value pairs
+        var results []*yaml.Node
+        for i := 0; i < len(node.Content); i += 2 {
+            key := node.Content[i]
+            value := node.Content[i+1]
+            // Process key-value pair
+        }
+        return &yaml.Node{
+            Kind:    yaml.MappingNode,
+            Tag:     "!!map",
+            Content: results,
+        }, nil
+        
+    default:
+        return nil, errors.New("expected sequence or mapping node")
+    }
+}
+```
+
+### Variable Expansion
+
+Variable expansion is a common requirement that needs careful handling to:
+- Maintain proper scoping
+- Handle circular references
+- Provide clear error messages
+- Support nested expansion
+
+```go
+func handleWithExpansion(ei *emrichen.Interpreter, node *yaml.Node) (*yaml.Node, error) {
+    // First process the node to expand any variables
+    expanded, err := ei.Process(node)
+    if err != nil {
+        return nil, err
+    }
+    
+    // Then process the expanded result
+    return processExpanded(ei, expanded)
+}
+```
+
+## Conclusion
+
+Custom tags provide a powerful way to extend Go-Emrichen's functionality. By following these patterns and best practices, you can create robust and reusable tags that integrate seamlessly with the templating system.
+
+The key to successful tag implementation lies in:
+- Understanding the YAML node structure
+- Proper error handling and validation
+- Clean and maintainable code
+- Comprehensive testing
+- Clear documentation
+
+Remember to:
+- Validate inputs thoroughly
+- Handle errors gracefully
+- Document your tags clearly
+- Test edge cases
+- Consider performance implications
+
+For more examples, look at the built-in tag implementations in the Go-Emrichen source code. 

--- a/pkg/emrichen/filter.go
+++ b/pkg/emrichen/filter.go
@@ -10,7 +10,7 @@ func (ei *Interpreter) handleFilter(node *yaml.Node) (*yaml.Node, error) {
 		return nil, errors.New("!Filter requires a mapping node")
 	}
 
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "over", Required: true, Expand: true},
 		{Name: "test"},
 		{Name: "as"},

--- a/pkg/emrichen/group.go
+++ b/pkg/emrichen/group.go
@@ -2,6 +2,7 @@ package emrichen
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -11,7 +12,7 @@ func (ei *Interpreter) handleGroup(node *yaml.Node) (*yaml.Node, error) {
 		return nil, errors.New("!Group requires a mapping node")
 	}
 
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "over", Required: true, Expand: true},
 		{Name: "by", Required: true},
 		{Name: "template"},

--- a/pkg/emrichen/if.go
+++ b/pkg/emrichen/if.go
@@ -3,7 +3,7 @@ package emrichen
 import "gopkg.in/yaml.v3"
 
 func (ei *Interpreter) handleIf(node *yaml.Node) (*yaml.Node, error) {
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "test", Required: true},
 		{Name: "then"},
 		{Name: "else"},

--- a/pkg/emrichen/index.go
+++ b/pkg/emrichen/index.go
@@ -2,13 +2,14 @@ package emrichen
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
-	"os"
 )
 
 func (ei *Interpreter) handleIndex(node *yaml.Node) (*yaml.Node, error) {
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "over", Required: true, Expand: true},
 		{Name: "by", Required: true},
 		{Name: "template"},

--- a/pkg/emrichen/join.go
+++ b/pkg/emrichen/join.go
@@ -1,9 +1,10 @@
 package emrichen
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 func (ei *Interpreter) handleJoin(node *yaml.Node) (*yaml.Node, error) {
@@ -11,7 +12,7 @@ func (ei *Interpreter) handleJoin(node *yaml.Node) (*yaml.Node, error) {
 	itemsNode := node
 
 	if node.Kind == yaml.MappingNode {
-		args, err := ei.parseArgs(node, []parsedVariable{
+		args, err := ei.ParseArgs(node, []ParsedVariable{
 			// don't expand items here yet
 			{Name: "items", Required: true, Expand: true},
 			{Name: "separator", Expand: true},

--- a/pkg/emrichen/loop.go
+++ b/pkg/emrichen/loop.go
@@ -10,7 +10,7 @@ func (ei *Interpreter) handleLoop(node *yaml.Node) (*yaml.Node, error) {
 		return nil, errors.New("!Loop requires a mapping node")
 	}
 
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "over", Required: true, Expand: true},
 		{Name: "template", Required: true},
 		{Name: "as"},

--- a/pkg/emrichen/op.go
+++ b/pkg/emrichen/op.go
@@ -1,15 +1,16 @@
 package emrichen
 
 import (
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 )
 
 func (ei *Interpreter) handleOp(node *yaml.Node) (*yaml.Node, error) {
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "op", Required: true, Expand: true},
 		{Name: "a", Required: true, Expand: true},
 		{Name: "b", Required: true, Expand: true},

--- a/pkg/emrichen/parser.go
+++ b/pkg/emrichen/parser.go
@@ -5,13 +5,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type parsedVariable struct {
+type ParsedVariable struct {
 	Name     string
 	Expand   bool
 	Required bool
 }
 
-// parseArgs processes a YAML mapping node according to a list of variable specifications.
+// ParseArgs processes a YAML mapping node according to a list of variable specifications.
 // It's a core utility function used by various Emrichen tags to parse their arguments
 // in a consistent way.
 //
@@ -36,21 +36,21 @@ type parsedVariable struct {
 //
 // Example usage:
 //
-//	args, err := ei.parseArgs(node, []parsedVariable{
+//	args, err := ei.ParseArgs(node, []parsedVariable{
 //	  {Name: "test", Required: true, Expand: true},
 //	  {Name: "then", Required: true, Expand: false},
 //	  {Name: "else", Required: false, Expand: false},
 //	})
-func (ei *Interpreter) parseArgs(
+func (ei *Interpreter) ParseArgs(
 	node *yaml.Node,
-	variables []parsedVariable,
+	variables []ParsedVariable,
 ) (map[string]*yaml.Node, error) {
 	argsMap := make(map[string]*yaml.Node)
 	if node.Kind != yaml.MappingNode {
 		return nil, errors.New("expected a mapping node")
 	}
 
-	varMap := make(map[string]parsedVariable)
+	varMap := make(map[string]ParsedVariable)
 	for _, v := range variables {
 		varMap[v.Name] = v
 	}
@@ -101,7 +101,7 @@ func (ei *Interpreter) parseArgs(
 //
 // Note: The 'query' parameter is optional and can be a mapping node containing key-value pairs of query parameters.
 func (ei *Interpreter) parseURLEncodeArgs(node *yaml.Node) (string, map[string]interface{}, error) {
-	args, err := ei.parseArgs(node, []parsedVariable{
+	args, err := ei.ParseArgs(node, []ParsedVariable{
 		{Name: "url", Required: true, Expand: true},
 		{Name: "query", Expand: true},
 	})

--- a/pkg/emrichen/parser.go
+++ b/pkg/emrichen/parser.go
@@ -11,6 +11,36 @@ type parsedVariable struct {
 	Required bool
 }
 
+// parseArgs processes a YAML mapping node according to a list of variable specifications.
+// It's a core utility function used by various Emrichen tags to parse their arguments
+// in a consistent way.
+//
+// Parameters:
+// - node: A pointer to a yaml.Node that must be a mapping node containing key-value pairs
+// - variables: A slice of parsedVariable structs that specify:
+//   - Name: The expected argument name
+//   - Required: Whether the argument must be present
+//   - Expand: Whether to process the value through the Emrichen interpreter
+//
+// Returns:
+// - map[string]*yaml.Node: A map of processed arguments where:
+//   - Keys are the argument names
+//   - Values are the processed YAML nodes (expanded if specified)
+//
+// - error: Returns an error if:
+//   - The input node is not a mapping node
+//   - An unknown argument key is encountered
+//   - A required argument is missing
+//   - A key is not a scalar value
+//   - Value expansion fails
+//
+// Example usage:
+//
+//	args, err := ei.parseArgs(node, []parsedVariable{
+//	  {Name: "test", Required: true, Expand: true},
+//	  {Name: "then", Required: true, Expand: false},
+//	  {Name: "else", Required: false, Expand: false},
+//	})
 func (ei *Interpreter) parseArgs(
 	node *yaml.Node,
 	variables []parsedVariable,

--- a/test-data/defaults-var-format.yml
+++ b/test-data/defaults-var-format.yml
@@ -1,9 +1,9 @@
 !Defaults
 name: John
 age: 30
-
+---
 person:
   name: !Var name
   age: !Var age
-  greeting: !Format "Hello, {{.name})! You are {{.age}} years old."
+  greeting: !Format "Hello, {{.name}}! You are {{.age}} years old."
 

--- a/test-data/loop-concat.yml
+++ b/test-data/loop-concat.yml
@@ -5,19 +5,15 @@ items:
   - item3
 ---
 # Use the !Loop tag to iterate over the sequence
-result: 
-  !Loop
-    over: !Var items
-    as: item
-    template:
-      !With
-        # Define a local variable 'message' for each iteration
-        variable:
-          name: message
-          value: 
-            !Concat ["Processing ", !Var item]
-
-        # Use the defined variable 'message'
-        body: 
-          !Var message
+result: !Concat,Loop
+  over: !Var items
+  as: item
+  template: !With
+    # Define a local variable 'message' for each iteration
+    vars:
+      message: 
+        - "Processing "
+        - !Var item
+    # Use the defined variable 'message'
+    template: !Var message
 

--- a/test-data/loop-url-encode.yml
+++ b/test-data/loop-url-encode.yml
@@ -18,5 +18,5 @@ query_map:
   template: !Loop
     over: !Var encoded_urls
     as: url_info
-    template: !Format "Url: {{url_with_query}}"
+    template: !Format "Url: {{.url_info.url_with_query}}"
 


### PR DESCRIPTION
Major refactoring of the tag handling system to make it more maintainable and 
extensible:

Core Changes:
- Replace large switch statement with map of handler functions
- Add TagFunc type with interpreter instance parameter
- Move built-in tag handlers to defaultHandlers map
- Make ParseArgs public and add comprehensive documentation
- Update RegisterTag to wrap old-style functions

Documentation:
- Add comprehensive guide for implementing custom tags

No breaking changes to existing tag behavior or public APIs.